### PR TITLE
Fix error when using multiline lambdas in `until` method

### DIFF
--- a/busypie/func.py
+++ b/busypie/func.py
@@ -28,5 +28,6 @@ def _is_a_lambda(func: Callable) -> bool:
 
 def _content_of(lambda_func: Callable) -> str:
     source_line = inspect.getsource(lambda_func)
+    source_line = re.sub(r'\s+', ' ', source_line)
     r = re.search(r'lambda[^:]*:\s*(.+)\s*\)', source_line)
     return r.group(1)


### PR DESCRIPTION
I know multi-line lambdas in Python sounds strange, but hear me out. In a project of mine, I use Black for code formatting, and Black sometimes can format l long lambdas like this

```python
wait().at_most(5).until_asserted(
        lambda: (
            super_long_assert_assert_function(
                param1,
                param2,
                param3,
                param4,
            )
        )
    )

```

So in this case busypie fails with the following message

`AttributeError: 'NoneType' object has no attribute 'group'`

After some digging, I found that busypie inspects the lambda function and runs a regex on the source. In this case, the regex is failing to match. I'm talking about this function in `func.py` file

```python
def _content_of(lambda_func: Callable) -> str:
    source_line = inspect.getsource(lambda_func)
    r = re.search(r'lambda[^:]*:\s*(.+)\s*\)', source_line) # <- this regex fails to math the source code of the lambda
    return r.group(1)   
```

My naive solution for a fix is to replace one or more whitespace characters with a single whitespace character. This removes the new lines and the regex is matching now. I've run the tests and they all pass
